### PR TITLE
support dependencies across multiple namespaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags: ['[0-9]*']
+    tags: ["[0-9]*"]
   pull_request:
     branches:
       - main
@@ -16,14 +16,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      run: |
-        rustup update stable --no-self-update
-        rustup default stable
-      shell: bash
-    - name: Run all tests
-      run: cargo test --all
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+        shell: bash
+      - name: Run all tests
+        run: cargo test --all
 
   check:
     name: Check feature combinations
@@ -32,29 +32,27 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      run: |
-        rustup update stable --no-self-update
-        rustup default stable
-      shell: bash
-    - name: Build without default features
-      run: cargo check --no-default-features
-    - name: Build the `wat` feature
-      run: cargo check --no-default-features --features wat
-    - name: Build the `wit` feature
-      run: cargo check --no-default-features --features wit
-    - name: Build the `registry` feature
-      run: cargo check --no-default-features --features registry
-    - name: Build all features
-      run: cargo check --all-features
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+        shell: bash
+      - name: Build without default features
+        run: cargo check --no-default-features
+      - name: Build the `wat` feature
+        run: cargo check --no-default-features --features wat
+      - name: Build the `wit` feature
+        run: cargo check --no-default-features --features wit
+      - name: Build all features
+        run: cargo check --all-features
 
   rustfmt:
     name: Format source code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - name: Run `cargo fmt`
-      run: cargo fmt -- --check
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup component add rustfmt
+      - name: Run `cargo fmt`
+        run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1441,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -3036,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -3173,6 +3186,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static 1.4.0",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3847,6 +3866,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dialoguer",
  "indexmap 2.2.6",
  "indicatif",
  "log",
@@ -3862,6 +3882,7 @@ dependencies = [
  "wac-parser",
  "wac-resolver",
  "wac-types",
+ "warg-client",
  "wasmprinter 0.202.0",
  "wat",
 ]
@@ -3929,6 +3950,7 @@ dependencies = [
  "pretty_assertions",
  "secrecy",
  "semver",
+ "serde_json",
  "tempdir",
  "thiserror",
  "tokio",
@@ -3987,9 +4009,8 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bf1e22e1e396b98a2181219b06d1a49a3478c1b9d87a29cd9cd819d714e6c3"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -4002,9 +4023,8 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56cfaf9781ca2d084468bbdd8bbc1e35947bb2a19f8d3940d899852f6dd78aa"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4046,9 +4066,8 @@ dependencies = [
 
 [[package]]
 name = "warg-credentials"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626224ba1a00965282b669d2611654fd6292a15396ed8c850ce91684678fe19f"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4060,9 +4079,8 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a8c47e96a7f1903931b34db9a1f0d22bcb3761a203ee6861db686daaedcb4b"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "base64",
@@ -4081,9 +4099,8 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed0e698efd0fab8bb747efd452156a65149eb389f7fe2a6b6b3ced4e25ab24"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4100,9 +4117,8 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69be98a2e9e0aeace7cbd62184b11462d259c5e391e6208d59506c9a2d33571c"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "base64",
@@ -4123,9 +4139,8 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f15457ced83df5c2298f225fc83b6700e93c7bf320a2e4ef01114c0b34d7ce"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "axum",
@@ -4154,9 +4169,8 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d272b3002b9e5f6f636817089ba091e1ba7b85858e72529f96e24bc9827f530"
+version = "0.5.0-dev"
+source = "git+https://github.com/bytecodealliance/registry?branch=namespace-enhancements#fd8c963660644f1b13cc8547731fbbcf749e1178"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,14 @@ thiserror = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 semver = { workspace = true }
-indicatif = { workspace = true, optional = true }
+indicatif = { workspace = true }
+warg-client = { workspace = true }
+dialoguer = "0.11.0"
 
 [features]
 default = ["wit"]
 wat = ["wac-resolver/wat"]
 wit = ["wac-resolver/wit"]
-registry = ["wac-resolver/registry", "indicatif"]
 
 [workspace.dependencies]
 wac-parser = { path = "crates/wac-parser", version = "0.1.0", default-features = false }
@@ -71,11 +72,11 @@ wat = "1.202.0"
 logos = "0.14.0"
 miette = "7.2.0"
 thiserror = "1.0.58"
-warg-client = "0.4.1"
-warg-protocol = "0.4.1"
-warg-crypto = "0.4.1"
-warg-server = "0.4.1"
-warg-credentials = "0.4.1"
+warg-protocol = { git = "https://github.com/bytecodealliance/registry", branch = "namespace-enhancements" }
+warg-crypto = { git = "https://github.com/bytecodealliance/registry", branch = "namespace-enhancements" }
+warg-client = { git = "https://github.com/bytecodealliance/registry", branch = "namespace-enhancements" }
+warg-credentials = { git = "https://github.com/bytecodealliance/registry", branch = "namespace-enhancements" }
+warg-server = { git = "https://github.com/bytecodealliance/registry", branch = "namespace-enhancements" }
 secrecy = "0.8.0"
 futures = "0.3.30"
 indicatif = "0.17.8"

--- a/crates/wac-resolver/Cargo.toml
+++ b/crates/wac-resolver/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 wac-types = { workspace = true }
 wac-parser = { workspace = true }
 semver = { workspace = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 anyhow = { workspace = true }
 log = { workspace = true }
 wit-component = { workspace = true }
@@ -21,13 +21,14 @@ indexmap = { workspace = true }
 wat = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true }
 miette = { workspace = true }
-warg-client = { workspace = true, optional = true }
-warg-protocol = { workspace = true, optional = true }
-warg-crypto = { workspace = true, optional = true }
-warg-credentials = { workspace = true, optional = true }
-secrecy = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
+warg-client = { workspace = true }
+warg-protocol = { workspace = true }
+warg-crypto = { workspace = true }
+warg-credentials = { workspace = true }
+secrecy = { workspace = true}
+tokio = { workspace = true}
+futures = { workspace = true}
+serde_json = "1.0.116"
 
 [dev-dependencies]
 wac-graph = { workspace = true }
@@ -38,7 +39,7 @@ tokio-util = "0.7.10"
 tempdir = "0.3.7"
 
 [features]
-default = ["registry"]
+default = []
 wat = ["dep:wat"]
 wit = ["wit-parser"]
-registry = ["warg-client", "warg-protocol", "warg-crypto", "warg-credentials", "secrecy", "tokio", "futures"]
+

--- a/crates/wac-resolver/Cargo.toml
+++ b/crates/wac-resolver/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 wac-types = { workspace = true }
 wac-parser = { workspace = true }
 semver = { workspace = true }
-thiserror.workspace = true
+thiserror = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true }
 wit-component = { workspace = true }
@@ -25,9 +25,9 @@ warg-client = { workspace = true }
 warg-protocol = { workspace = true }
 warg-crypto = { workspace = true }
 warg-credentials = { workspace = true }
-secrecy = { workspace = true}
-tokio = { workspace = true}
-futures = { workspace = true}
+secrecy = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
 serde_json = "1.0.116"
 
 [dev-dependencies]

--- a/crates/wac-resolver/src/lib.rs
+++ b/crates/wac-resolver/src/lib.rs
@@ -161,10 +161,10 @@ pub enum CommandError {
     #[error(transparent)]
     Wac(#[from] WacError),
     /// Client Error
-    #[error("warg client error: {0}")]
+    #[error("warg client error ({0}): {1}")]
     WargClient(String, ClientError),
     /// Client Error With Hint
-    #[error("warg client error with hint: {0}")]
+    #[error("warg client error with hint ({0}): {1}")]
     WargHint(String, ClientError),
 }
 

--- a/crates/wac-resolver/src/registry.rs
+++ b/crates/wac-resolver/src/registry.rs
@@ -46,13 +46,14 @@ impl RegistryPackageResolver {
     /// client configuration file.
     ///
     /// If `url` is `None`, the default URL will be used.
+    ///
+    /// The `Retry` argument indicates that this was created after an interactive retry.
+    /// This occurs when the CLI attempted to leverage a package from the wrong registry.
+    /// The server responds with a hint as to which registry is used and the client maps that package namespace to the domain provided.
+    /// After this, the CLI command is retried
     pub async fn new(
         url: Option<&str>,
         bar: Option<Box<dyn ProgressBar>>,
-        // Indicates that this was created after an interactive retry.
-        // This occurs when the CLI attempted to leverage a package from the wrong registry.
-        // The server responds with a hint as to which registry is used and the client maps that package namespace to the domain provided.
-        // After this, the CLI command is retried
         retry: Option<Retry>,
     ) -> Result<Self> {
         let config = Config::from_default_file()?.unwrap_or_default();

--- a/crates/wac-resolver/tests/registry.rs
+++ b/crates/wac-resolver/tests/registry.rs
@@ -61,7 +61,7 @@ export i2.foo as "bar";
 "#,
     )?;
 
-    let resolver = RegistryPackageResolver::new_with_config(None, &config, None)?;
+    let resolver = RegistryPackageResolver::new_with_config(None, &config, None).await?;
     let packages = resolver.resolve(&packages(&document)?).await?;
 
     let resolution = document.resolve(packages)?;

--- a/crates/wac-resolver/tests/support/mod.rs
+++ b/crates/wac-resolver/tests/support/mod.rs
@@ -64,7 +64,7 @@ pub async fn publish(
     content: Vec<u8>,
     init: bool,
 ) -> Result<()> {
-    let client = FileSystemClient::new_with_config(None, config, None)?;
+    let client = FileSystemClient::new_with_config(None, config, None).await?;
 
     let digest = client
         .content()

--- a/crates/wac-types/src/package.rs
+++ b/crates/wac-types/src/package.rs
@@ -56,7 +56,7 @@ impl fmt::Display for PackageKey {
 }
 
 /// A borrowed package key.
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct BorrowedPackageKey<'a> {
     /// The package name.
     pub name: &'a str,

--- a/src/bin/wac.rs
+++ b/src/bin/wac.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
             Wac::Resolve(cmd) => cmd.exec(retry).await,
             Wac::Encode(cmd) => cmd.exec(retry).await,
         } {
-            if let CommandError::WargHint(ClientError::PackageDoesNotExistWithHint { name, hint }) = &err {
+            if let CommandError::WargHint(_, ClientError::PackageDoesNotExistWithHint { name, hint }) = &err {
                 if let Some((namespace, registry)) = hint.to_str().unwrap().split_once('=') {
                     let prompt = format!(
                       "The package `{}`, does not exist in the registry you're using.
@@ -66,13 +66,15 @@ async fn main() -> Result<()> {
                           },
                         }
                           {
-                        eprintln!(
-                          "{error}: {e:?}",
-                          error = "error".if_supports_color(Stream::Stderr, |text| {
-                              text.style(Style::new().red().bold())
-                          })
-                      );
-                      std::process::exit(1);
+                            eprintln!(
+                              "{error}: {e:?}",
+                              error = "error".if_supports_color(Stream::Stderr, |text| {
+                                text.style(Style::new().red().bold())
+                              })
+                            );
+                          std::process::exit(1);
+                        } else {
+                          return Ok(());
                         }
                     }
                 }

--- a/src/bin/wac.rs
+++ b/src/bin/wac.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use clap::Parser;
+use dialoguer::{theme::ColorfulTheme, Confirm};
 use owo_colors::{OwoColorize, Stream, Style};
 use wac_cli::commands::{EncodeCommand, ParseCommand, ResolveCommand};
+use wac_resolver::CommandError;
+use warg_client::{with_interactive_retry, ClientError, Retry};
 
 fn version() -> &'static str {
     option_env!("CARGO_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
@@ -26,19 +29,103 @@ enum Wac {
 async fn main() -> Result<()> {
     pretty_env_logger::init();
 
-    if let Err(e) = match Wac::parse() {
-        Wac::Parse(cmd) => cmd.exec().await,
-        Wac::Resolve(cmd) => cmd.exec().await,
-        Wac::Encode(cmd) => cmd.exec().await,
-    } {
-        eprintln!(
-            "{error}: {e:?}",
-            error = "error".if_supports_color(Stream::Stderr, |text| {
-                text.style(Style::new().red().bold())
-            })
-        );
-        std::process::exit(1);
-    }
-
+    with_interactive_retry(|retry: Option<Retry>| async {
+        if let Err(e) = match Wac::parse() {
+            Wac::Parse(cmd) => cmd.exec().await,
+            Wac::Resolve(cmd) => cmd.exec(retry).await,
+            Wac::Encode(cmd) => cmd.exec(retry).await,
+        } {
+            match e {
+                CommandError::General(e) => {
+                    eprintln!(
+                        "{error}: {e:?}",
+                        error = "error".if_supports_color(Stream::Stderr, |text| {
+                            text.style(Style::new().red().bold())
+                        })
+                    );
+                    std::process::exit(1);
+                }
+                CommandError::Serde(e) => {
+                    eprintln!(
+                        "{error}: {e:?}",
+                        error = "error".if_supports_color(Stream::Stderr, |text| {
+                            text.style(Style::new().red().bold())
+                        })
+                    );
+                    std::process::exit(1);
+                }
+                CommandError::Wac(e) => {
+                    eprintln!(
+                        "{error}: {e:?}",
+                        error = "error".if_supports_color(Stream::Stderr, |text| {
+                            text.style(Style::new().red().bold())
+                        })
+                    );
+                    std::process::exit(1);
+                }
+                CommandError::WacResolution(e) => {
+                      eprintln!(
+                          "{error}: {e:?}",
+                          error = "error".if_supports_color(Stream::Stderr, |text| {
+                              text.style(Style::new().red().bold())
+                          })
+                      );
+                      std::process::exit(1);
+                    },
+                CommandError::WargClient(e) => {
+                    eprintln!(
+                        "{error}: {e:?}",
+                        error = "error".if_supports_color(Stream::Stderr, |text| {
+                            text.style(Style::new().red().bold())
+                        })
+                    );
+                    std::process::exit(1);
+                }
+                CommandError::WargHint(e) => {
+                    if let ClientError::PackageDoesNotExistWithHint { name, hint } = e {
+                        let hint_reg = hint.to_str().unwrap();
+                        let mut terms = hint_reg.split('=');
+                        let namespace = terms.next();
+                        let registry = terms.next();
+                        if let (Some(namespace), Some(registry)) = (namespace, registry) {
+                            let prompt = format!(
+                          "The package `{}`, does not exist in the registry you're using.\nHowever, the package namespace `{namespace}` does exist in the registry at {registry}.\nWould you like to configure your warg cli to use this registry for packages with this namespace in the future? y/N\n",
+                          name.name()
+                        );
+                            if Confirm::with_theme(&ColorfulTheme::default())
+                                .with_prompt(prompt)
+                                .interact()
+                                .unwrap()
+                            {
+                                if let Err(e) = match Wac::parse() {
+                                  Wac::Parse(cmd) => cmd.exec().await,
+                                  Wac::Resolve(cmd) => cmd.exec(Some(Retry::new(
+                                                        namespace.to_string(),
+                                                        registry.to_string(),
+                                                    )))
+                                                    .await,
+                                  Wac::Encode(cmd) => cmd.exec(Some(Retry::new(
+                                    namespace.to_string(),
+                                    registry.to_string(),
+                                )))
+                                .await
+                              } {
+                                eprintln!(
+                                  "{error}: {e:?}",
+                                  error = "error".if_supports_color(Stream::Stderr, |text| {
+                                      text.style(Style::new().red().bold())
+                                  })
+                              );
+                              std::process::exit(1);
+                        }
+                    }
+                    }
+                }
+                }
+            }
+        }
+        Ok(())
+    })
+    .await?;
     Ok(())
 }

--- a/src/commands/encode.rs
+++ b/src/commands/encode.rs
@@ -97,8 +97,7 @@ impl EncodeCommand {
         if !self.wat && self.output.is_none() && std::io::stdout().is_terminal() {
             return Err(anyhow!(
             "cannot print binary wasm output to a terminal; pass the `-t` flag to print the text format instead"
-        )
-        .into());
+        ))?;
         }
 
         let mut bytes = resolution

--- a/src/commands/parse.rs
+++ b/src/commands/parse.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use clap::Args;
 use std::{fs, path::PathBuf};
 use wac_parser::Document;
+use wac_resolver::CommandError;
 
 /// Parses a WAC source file into a JSON AST representation.
 #[derive(Args)]
@@ -15,7 +16,7 @@ pub struct ParseCommand {
 
 impl ParseCommand {
     /// Executes the command.
-    pub async fn exec(self) -> Result<()> {
+    pub async fn exec(self) -> Result<(), CommandError> {
         log::debug!("executing parse command");
 
         let contents = fs::read_to_string(&self.path)
@@ -23,7 +24,8 @@ impl ParseCommand {
 
         let document = Document::parse(&contents).map_err(|e| fmt_err(e, &self.path, &contents))?;
 
-        serde_json::to_writer_pretty(std::io::stdout(), &document)?;
+        serde_json::to_writer_pretty(std::io::stdout(), &document)
+            .map_err(|e| CommandError::Serde(e))?;
         println!();
 
         Ok(())


### PR DESCRIPTION
This leverages https://github.com/bytecodealliance/registry/pull/263 from warg-client enabling wac to have dependencies across multiple registries/namespaces. The CLI now takes advantage of the namespace mappings that the warg client provides in its local storage.

Worth noting... if a user attempts to depend on a package that doesn't exist in the registry they're using, but does exist in another registry that their registry is aware of, it can provide a hint indicating that the user can update their namespace mappings to enable communication with the proper registry. This use case also required the addition of logic to retry many of the CLI commands after updating local namespace storage with the proper hint, preserving the same user experience that the warg CLI has.

I also figured it makes sense at this point to remove the feature flag that the registry support is behind, unless I missed some rationale for the flag.  Figured I could easily add it back if there are any reasons not to.