### PR TITLE
New `wac plug` command

### DIFF
--- a/src/bin/wac.rs
+++ b/src/bin/wac.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use owo_colors::{OwoColorize, Stream, Style};
-use wac_cli::commands::{EncodeCommand, ParseCommand, ResolveCommand};
+use wac_cli::commands::{EncodeCommand, ParseCommand, PlugCommand, ResolveCommand};
 
 fn version() -> &'static str {
     option_env!("CARGO_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
@@ -20,6 +20,7 @@ enum Wac {
     Parse(ParseCommand),
     Resolve(ResolveCommand),
     Encode(EncodeCommand),
+    Plug(PlugCommand),
 }
 
 #[tokio::main]
@@ -30,6 +31,7 @@ async fn main() -> Result<()> {
         Wac::Parse(cmd) => cmd.exec().await,
         Wac::Resolve(cmd) => cmd.exec().await,
         Wac::Encode(cmd) => cmd.exec().await,
+        Wac::Plug(cmd) => cmd.exec().await,
     } {
         eprintln!(
             "{error}: {e:?}",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,8 +2,10 @@
 
 mod encode;
 mod parse;
+mod plug;
 mod resolve;
 
 pub use self::encode::*;
 pub use self::parse::*;
+pub use self::plug::*;
 pub use self::resolve::*;

--- a/src/commands/plug.rs
+++ b/src/commands/plug.rs
@@ -2,17 +2,21 @@ use std::{io::Write as _, path::PathBuf};
 
 use anyhow::{Context as _, Result};
 use clap::Args;
-use wac_graph::{CompositionGraph, EncodeOptions};
+use wac_graph::{CompositionGraph, EncodeOptions, NodeId, PackageId};
 use wac_types::{Package, SubtypeChecker};
 
 /// Plugs the exports of any number of 'plug' components into the imports of a 'socket' component.
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
 pub struct PlugCommand {
-    /// The path to the plug component
-    pub plug: PathBuf,
+    /// The path to the plug component.
+    ///
+    /// More than one plug can be supplied.
+    #[clap(long = "plug", value_name = "PLUG_PATH", required = true)]
+    pub plugs: Vec<PathBuf>,
 
     /// The path to the socket component
+    #[clap(value_name = "SOCKET_PATH", required = true)]
     pub socket: PathBuf,
 
     /// The path to write the output to.
@@ -28,44 +32,35 @@ impl PlugCommand {
         log::debug!("executing plug command");
         let mut graph = CompositionGraph::new();
 
-        let plug = std::fs::read(&self.plug).with_context(|| {
-            format!(
-                "failed to read plug component `{path}`",
-                path = self.plug.display()
-            )
-        })?;
         let socket = std::fs::read(&self.socket).with_context(|| {
             format!(
                 "failed to read socket component `{path}`",
-                path = self.plug.display()
+                path = self.socket.display()
             )
         })?;
 
-        // Register the packages
-        let plug = Package::from_bytes("plug", None, plug, graph.types_mut())?;
-        let plug = graph.register_package(plug)?;
         let socket = Package::from_bytes("socket", None, socket, graph.types_mut())?;
         let socket = graph.register_package(socket)?;
-
         let socket_instantiation = graph.instantiate(socket);
-        let plug_instantiation = graph.instantiate(plug);
-        let mut plugs = Vec::new();
-        let mut cache = Default::default();
-        let mut checker = SubtypeChecker::new(&mut cache);
-        for (name, plug_ty) in &graph.types()[graph[plug].ty()].exports {
-            if let Some(socket_ty) = graph.types()[graph[socket].ty()].imports.get(name) {
-                if let Ok(_) =
-                    checker.is_subtype(*plug_ty, graph.types(), *socket_ty, graph.types())
-                {
-                    plugs.push(name.clone());
-                }
-            }
+
+        // Plug each plug into the socket.
+        for (i, plug) in self.plugs.iter().enumerate() {
+            let plug = std::fs::read(&plug).with_context(|| {
+                format!(
+                    "failed to read plug component `{path}`",
+                    path = plug.display()
+                )
+            })?;
+            plug_into_socket(
+                &format!("plug{i}"),
+                plug,
+                socket,
+                socket_instantiation,
+                &mut graph,
+            )?;
         }
-        for plug in plugs {
-            log::debug!("using export `{plug}` for plug");
-            let export = graph.alias_instance_export(plug_instantiation, &plug)?;
-            graph.set_instantiation_argument(socket_instantiation, &plug, export)?;
-        }
+
+        // Export all exports from the socket component.
         for name in graph.types()[graph[socket].ty()]
             .exports
             .keys()
@@ -92,4 +87,35 @@ impl PlugCommand {
         }
         Ok(())
     }
+}
+
+/// Take the exports of the plug component and plug them into the socket component.
+fn plug_into_socket(
+    name: &str,
+    plug: Vec<u8>,
+    socket: PackageId,
+    socket_instantiation: NodeId,
+    graph: &mut CompositionGraph,
+) -> Result<(), anyhow::Error> {
+    let plug = Package::from_bytes(name, None, plug, graph.types_mut())?;
+    let plug = graph.register_package(plug)?;
+    let plug_instantiation = graph.instantiate(plug);
+
+    let mut plugs = Vec::new();
+    let mut cache = Default::default();
+    let mut checker = SubtypeChecker::new(&mut cache);
+    for (name, plug_ty) in &graph.types()[graph[plug].ty()].exports {
+        if let Some(socket_ty) = graph.types()[graph[socket].ty()].imports.get(name) {
+            if let Ok(_) = checker.is_subtype(*plug_ty, graph.types(), *socket_ty, graph.types()) {
+                plugs.push(name.clone());
+            }
+        }
+    }
+
+    for plug in plugs {
+        log::debug!("using export `{plug}` for plug");
+        let export = graph.alias_instance_export(plug_instantiation, &plug)?;
+        graph.set_instantiation_argument(socket_instantiation, &plug, export)?;
+    }
+    Ok(())
 }

--- a/src/commands/plug.rs
+++ b/src/commands/plug.rs
@@ -1,0 +1,95 @@
+use std::{io::Write as _, path::PathBuf};
+
+use anyhow::{Context as _, Result};
+use clap::Args;
+use wac_graph::{CompositionGraph, EncodeOptions};
+use wac_types::{Package, SubtypeChecker};
+
+/// Plugs the exports of any number of 'plug' components into the imports of a 'socket' component.
+#[derive(Args)]
+#[clap(disable_version_flag = true)]
+pub struct PlugCommand {
+    /// The path to the plug component
+    pub plug: PathBuf,
+
+    /// The path to the socket component
+    pub socket: PathBuf,
+
+    /// The path to write the output to.
+    ///
+    /// If not specified, the output will be written to stdout.
+    #[clap(long, short = 'o')]
+    pub output: Option<PathBuf>,
+}
+
+impl PlugCommand {
+    /// Executes the command.
+    pub async fn exec(&self) -> Result<()> {
+        log::debug!("executing plug command");
+        let mut graph = CompositionGraph::new();
+
+        let plug = std::fs::read(&self.plug).with_context(|| {
+            format!(
+                "failed to read plug component `{path}`",
+                path = self.plug.display()
+            )
+        })?;
+        let socket = std::fs::read(&self.socket).with_context(|| {
+            format!(
+                "failed to read socket component `{path}`",
+                path = self.plug.display()
+            )
+        })?;
+
+        // Register the packages
+        let plug = Package::from_bytes("plug", None, plug, graph.types_mut())?;
+        let plug = graph.register_package(plug)?;
+        let socket = Package::from_bytes("socket", None, socket, graph.types_mut())?;
+        let socket = graph.register_package(socket)?;
+
+        let socket_instantiation = graph.instantiate(socket);
+        let plug_instantiation = graph.instantiate(plug);
+        let mut plugs = Vec::new();
+        let mut cache = Default::default();
+        let mut checker = SubtypeChecker::new(&mut cache);
+        for (name, plug_ty) in &graph.types()[graph[plug].ty()].exports {
+            if let Some(socket_ty) = graph.types()[graph[socket].ty()].imports.get(name) {
+                if let Ok(_) =
+                    checker.is_subtype(*plug_ty, graph.types(), *socket_ty, graph.types())
+                {
+                    plugs.push(name.clone());
+                }
+            }
+        }
+        for plug in plugs {
+            log::debug!("using export `{plug}` for plug");
+            let export = graph.alias_instance_export(plug_instantiation, &plug)?;
+            graph.set_instantiation_argument(socket_instantiation, &plug, export)?;
+        }
+        for name in graph.types()[graph[socket].ty()]
+            .exports
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            let export = graph.alias_instance_export(socket_instantiation, &name)?;
+            graph.export(export, &name)?;
+        }
+
+        let bytes = graph.encode(EncodeOptions::default())?;
+        match &self.output {
+            Some(path) => {
+                std::fs::write(&path, bytes).context(format!(
+                    "failed to write output file `{path}`",
+                    path = path.display()
+                ))?;
+            }
+            None => {
+                std::io::stdout()
+                    .write_all(&bytes)
+                    .context("failed to write to stdout")?;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #80 

This PR introduces the `wac plug` command. `wac plug` takes any number of "plug" components and a single "socket" component. It then attempts to find all exports in each plug that have a matching import (both by name and type) in the socket. It then composes all the components together by filling in the sockets imports with the exports from the plugs. 

All the exports of socket will be exported from the composition, and any unused exports of the plugs will be dropped. All imports from the plugs and any unplugged imports from the socket will be imported into the composition.

# Example

```wit
// hello.wasm
package example:hello;

world hello {
    export hello: func() -> string;
}
```

```wit
// greeter.wasm
package example:greeter;

world greeter {
    import hello: func() -> string;
    export greet: func() -> string;
}
```

We want to compose these two components into a component with the following wit:

```wit
package example:greeting;

world greeter {
  export greet: func() -> string;
}
```

To do this, we can run:

```
wac plug --plug hello.wasm greeter.wasm -o out.wasm
```