### PR TITLE
Warg update 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,10 +327,10 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -360,8 +360,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -419,6 +419,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -1236,25 +1242,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.2.6",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
@@ -1264,7 +1251,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.1.0",
+ "http",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1346,17 +1333,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1368,23 +1344,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1395,8 +1360,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1426,30 +1391,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.25",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.6",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
@@ -1457,28 +1398,32 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.3",
- "http 1.1.0",
- "http-body 1.0.0",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1488,13 +1433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.2.0",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2275,7 +2224,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "serde 1.0.197",
 ]
 
@@ -2785,20 +2734,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2815,6 +2766,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -2876,12 +2828,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
+ "rustls-pki-types",
 ]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustversion"
@@ -3100,7 +3059,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3564,6 +3523,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,8 +3627,8 @@ dependencies = [
  "bitflags 2.5.0",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4000,9 +3971,8 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08e86feb745fa5a4e9b3ed8c53ca7353ce474c9164573e7963c65eab0e20998"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -4015,9 +3985,8 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb95cdddbc52c73e774d6d555412bb8060156f1ac666df733c18bdeb923c22c"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4061,12 +4030,11 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79344c8bd2cf133533ce6352b6491fbb343e374a8c09527073adda5015c89c92"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "digest",
  "hex",
  "leb128",
@@ -4082,9 +4050,8 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975e38d2ddba1d26f46713d75cccecf3769ebaae7d14b0dcb830d207867c50bf"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4101,12 +4068,11 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb997bf019742f796123539e9c9031d3ec8ed973950a0534e1f6af508e27e4f1"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "hex",
  "indexmap 2.2.6",
  "pbjson-types",
@@ -4124,9 +4090,8 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ada7d9f5ec554959501509b60229da52f5bd0e535b6b83eef2ca4f7f47d127"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
  "axum",
@@ -4155,9 +4120,8 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04b4573fd7c7ebee61f5b4645b464e7dcd656386d0ca4c77b37533ad1bb98d9"
+version = "0.7.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4586,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,8 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a22d3c9026f2f6a628cf386963844cdb7baea3b3419ba090c9096da114f977d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3985,8 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8b5a2b17e737e1847dbf4642e4ebe49f5df32a574520251ff080ef0a120423"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4030,8 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834bf58863aa4bc3821732afb0c77e08a5cbf05f63ee93116acae694eab04460"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4050,8 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8a2dee6b14f5b0b0c461711a81cdef45d45ea94f8460cb6205cada7fec732a"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4068,8 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4053a3276d3fee83645411b1b5f462f72402e70fbf645164274a3a0a2fd72538"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4090,8 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfffee4ffd0f4d20263fe6fd4705b9ee311f6b482ca354a42cf4e78d55b58c51"
 dependencies = [
  "anyhow",
  "axum",
@@ -4120,8 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.7.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=972ddd7#972ddd7f9d4d1a05211aff01b4a2a28fa8106271"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513ef81a5bb1ac5d7bd04f90d3c192dad8f590f4c02b3ef68d3ae4fbbb53c1d7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,15 @@ wat = "1.202.0"
 logos = "0.14.0"
 miette = "7.2.0"
 thiserror = "1.0.58"
-warg-client = "0.6.0"
-warg-protocol = "0.6.0"
-warg-crypto = "0.6.0"
-warg-server = "0.6.0"
+
+warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
+warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
+warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
+warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
+#warg-client = "0.6.0"
+#warg-protocol = "0.6.0"
+#warg-crypto = "0.6.0"
+#warg-server = "0.6.0"
 futures = "0.3.30"
 indicatif = "0.17.8"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,15 +80,10 @@ wat = "1.202.0"
 logos = "0.14.0"
 miette = "7.2.0"
 thiserror = "1.0.58"
-
-warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
-warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
-warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
-warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "972ddd7" }
-#warg-client = "0.6.0"
-#warg-protocol = "0.6.0"
-#warg-crypto = "0.6.0"
-#warg-server = "0.6.0"
+warg-client = "0.7.0"
+warg-protocol = "0.7.0"
+warg-crypto = "0.7.0"
+warg-server = "0.7.0"
 futures = "0.3.30"
 indicatif = "0.17.8"
 pretty_assertions = "1.4.0"

--- a/crates/wac-resolver/src/registry.rs
+++ b/crates/wac-resolver/src/registry.rs
@@ -40,9 +40,9 @@ impl RegistryPackageResolver {
     /// client configuration file.
     ///
     /// If `url` is `None`, the default URL will be used.
-    pub fn new(url: Option<&str>, bar: Option<Box<dyn ProgressBar>>) -> Result<Self> {
+    pub async fn new(url: Option<&str>, bar: Option<Box<dyn ProgressBar>>) -> Result<Self> {
         Ok(Self {
-            client: Arc::new(Client::new_with_default_config(url)?),
+            client: Arc::new(Client::new_with_default_config(url).await?),
             bar,
         })
     }
@@ -50,13 +50,13 @@ impl RegistryPackageResolver {
     /// Creates a new registry package resolver with the given configuration.
     ///
     /// If `url` is `None`, the default URL will be used.
-    pub fn new_with_config(
+    pub async fn new_with_config(
         url: Option<&str>,
         config: &Config,
         bar: Option<Box<dyn ProgressBar>>,
     ) -> Result<Self> {
         Ok(Self {
-            client: Arc::new(Client::new_with_config(url, config, None)?),
+            client: Arc::new(Client::new_with_config(url, config, None).await?),
             bar,
         })
     }

--- a/crates/wac-resolver/tests/registry.rs
+++ b/crates/wac-resolver/tests/registry.rs
@@ -61,7 +61,7 @@ export i2.foo as "bar";
 "#,
     )?;
 
-    let resolver = RegistryPackageResolver::new_with_config(None, &config, None)?;
+    let resolver = RegistryPackageResolver::new_with_config(None, &config, None).await?;
     let packages = resolver.resolve(&packages(&document)?).await?;
 
     let resolution = document.resolve(packages)?;

--- a/crates/wac-resolver/tests/support/mod.rs
+++ b/crates/wac-resolver/tests/support/mod.rs
@@ -64,7 +64,7 @@ pub async fn publish(
     content: Vec<u8>,
     init: bool,
 ) -> Result<()> {
-    let client = FileSystemClient::new_with_config(None, config, None)?;
+    let client = FileSystemClient::new_with_config(None, config, None).await?;
 
     let digest = client
         .content()
@@ -148,6 +148,7 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
         content_dir: Some(root.join("content")),
         namespace_map_path: Some(root.join("namespaces")),
         keyring_auth: false,
+        keyring_backend: None,
         keys: Default::default(),
         ignore_federation_hints: false,
         auto_accept_federation_hints: false,

--- a/src/commands/encode.rs
+++ b/src/commands/encode.rs
@@ -84,7 +84,8 @@ impl EncodeCommand {
             self.deps.into_iter().collect(),
             #[cfg(feature = "registry")]
             self.registry.as_deref(),
-        )?;
+        )
+        .await?;
 
         let packages = resolver
             .resolve(&document)

--- a/src/commands/plug.rs
+++ b/src/commands/plug.rs
@@ -105,9 +105,9 @@ impl PlugCommand {
             #[cfg(feature = "registry")]
             PackageRef::RegistryPackage((name, version)) => {
                 if client.is_none() {
-                    client = Some(FileSystemClient::new_with_default_config(
-                        self.registry.as_deref(),
-                    ));
+                    client = Some(
+                        FileSystemClient::new_with_default_config(self.registry.as_deref()).await,
+                    );
                 }
                 let client = client.as_ref().unwrap().as_ref().map_err(|_| {
                     anyhow::anyhow!(
@@ -176,9 +176,10 @@ impl PlugCommand {
                     #[cfg(feature = "registry")]
                     PackageRef::RegistryPackage((name, version)) => {
                         if client.is_none() {
-                            client = Some(FileSystemClient::new_with_default_config(
-                                self.registry.as_deref(),
-                            ));
+                            client = Some(
+                                FileSystemClient::new_with_default_config(self.registry.as_deref())
+                                    .await,
+                            );
                         }
                         let client = client.as_ref().unwrap().as_ref().map_err(|_| {
                             anyhow::anyhow!(

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -56,7 +56,8 @@ impl ResolveCommand {
             self.deps.into_iter().collect(),
             #[cfg(feature = "registry")]
             self.registry.as_deref(),
-        )?;
+        )
+        .await?;
 
         let packages = resolver
             .resolve(&document)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub struct PackageResolver {
 
 impl PackageResolver {
     /// Creates a new package resolver.
-    pub fn new(
+    pub async fn new(
         dir: impl Into<PathBuf>,
         overrides: HashMap<String, PathBuf>,
         #[cfg(feature = "registry")] registry: Option<&str>,
@@ -63,7 +63,8 @@ impl PackageResolver {
             registry: wac_resolver::RegistryPackageResolver::new(
                 registry,
                 Some(Box::new(progress::ProgressBar::new())),
-            )?,
+            )
+            .await?,
         })
     }
 


### PR DESCRIPTION
Updating `warg` dependency to the latest release of `0.7.0`.