### PR TITLE
lazily create warg registry client

### DIFF
--- a/crates/wac-resolver/src/lib.rs
+++ b/crates/wac-resolver/src/lib.rs
@@ -19,6 +19,9 @@ use wac_types::BorrowedPackageKey;
 #[derive(thiserror::Error, Diagnostic, Debug)]
 #[diagnostic(code("failed to resolve document"))]
 pub enum Error {
+    /// Failed to create registry client.
+    #[error("failed to create registry client: {0:#}")]
+    RegistryClientFailed(anyhow::Error),
     /// An unknown package was encountered.
     #[error("unknown package `{name}`")]
     UnknownPackage {

--- a/src/commands/encode.rs
+++ b/src/commands/encode.rs
@@ -79,7 +79,7 @@ impl EncodeCommand {
 
         let document = Document::parse(&contents).map_err(|e| fmt_err(e, &self.path, &contents))?;
 
-        let resolver = PackageResolver::new(
+        let mut resolver = PackageResolver::new(
             self.deps_dir,
             self.deps.into_iter().collect(),
             #[cfg(feature = "registry")]

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -51,7 +51,7 @@ impl ResolveCommand {
 
         let document = Document::parse(&contents).map_err(|e| fmt_err(e, &self.path, &contents))?;
 
-        let resolver = PackageResolver::new(
+        let mut resolver = PackageResolver::new(
             self.deps_dir,
             self.deps.into_iter().collect(),
             #[cfg(feature = "registry")]


### PR DESCRIPTION
Due to the change in the `warg-client` to support the `.well-known` config redirection, creating the client triggers lookups. So we need to adjust the code to lazily instantiate the registry client to avoid unnecessarily triggering usage.

Fixes #122 