### PR TITLE
Update semver regex to not swallow trailing `.`

### DIFF
--- a/crates/wac-parser/src/lexer.rs
+++ b/crates/wac-parser/src/lexer.rs
@@ -95,7 +95,7 @@ fn detect_invalid_input(source: &str) -> Result<(), (Error, SourceSpan)> {
 #[logos(subpattern word = r"[a-z][a-z0-9]*|[A-Z][A-Z0-9]*")]
 #[logos(subpattern id = r"%?(?&word)(-(?&word))*")]
 #[logos(subpattern package_name = r"(?&id)(:(?&id))+")]
-#[logos(subpattern semver = r"[0-9a-zA-Z-\.\+]+")]
+#[logos(subpattern semver = r"([0-9]+)(\.[0-9a-zA-Z-\+]+)*")]
 pub enum Token {
     /// A comment.
     #[regex(r"//[^\n]*", logos::skip)]

--- a/crates/wac-parser/tests/parser/use.wac
+++ b/crates/wac-parser/tests/parser/use.wac
@@ -1,0 +1,6 @@
+package test:comp;
+
+interface my-handler {
+    use wasi:http/types@0.2.0.{incoming-request, response-outparam};
+    handle: func(request: incoming-request, response-out: response-outparam);
+}

--- a/crates/wac-parser/tests/parser/use.wac.result
+++ b/crates/wac-parser/tests/parser/use.wac.result
@@ -1,0 +1,126 @@
+{
+  "docs": [],
+  "directive": {
+    "package": {
+      "string": "test:comp",
+      "name": "test:comp",
+      "version": null,
+      "span": {
+        "offset": 8,
+        "length": 9
+      }
+    }
+  },
+  "statements": [
+    {
+      "Type": {
+        "interface": {
+          "docs": [],
+          "id": {
+            "string": "my-handler",
+            "span": {
+              "offset": 30,
+              "length": 10
+            }
+          },
+          "items": [
+            {
+              "use": {
+                "docs": [],
+                "path": {
+                  "package": {
+                    "span": {
+                      "offset": 51,
+                      "length": 21
+                    },
+                    "string": "wasi:http/types@0.2.0",
+                    "name": "wasi:http",
+                    "segments": "types",
+                    "version": "0.2.0"
+                  }
+                },
+                "items": [
+                  {
+                    "id": {
+                      "string": "incoming-request",
+                      "span": {
+                        "offset": 74,
+                        "length": 16
+                      }
+                    },
+                    "asId": null
+                  },
+                  {
+                    "id": {
+                      "string": "response-outparam",
+                      "span": {
+                        "offset": 92,
+                        "length": 17
+                      }
+                    },
+                    "asId": null
+                  }
+                ]
+              }
+            },
+            {
+              "export": {
+                "docs": [],
+                "id": {
+                  "string": "handle",
+                  "span": {
+                    "offset": 116,
+                    "length": 6
+                  }
+                },
+                "ty": {
+                  "func": {
+                    "params": [
+                      {
+                        "id": {
+                          "string": "request",
+                          "span": {
+                            "offset": 129,
+                            "length": 7
+                          }
+                        },
+                        "ty": {
+                          "ident": {
+                            "string": "incoming-request",
+                            "span": {
+                              "offset": 138,
+                              "length": 16
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "id": {
+                          "string": "response-out",
+                          "span": {
+                            "offset": 156,
+                            "length": 12
+                          }
+                        },
+                        "ty": {
+                          "ident": {
+                            "string": "response-outparam",
+                            "span": {
+                              "offset": 170,
+                              "length": 17
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "results": "empty"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #128.

The new regex is more complicated than `wac` likely needs - for example, it includes capture groups that the lexer discards.  The reason for choosing it was that it is suggested by the official semver site (https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).  Of course it can be trimmed back if necessary but that introduces the possibility of me messing it up... _grin_
