### PR TITLE
Rename encode to compose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wac-cli"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "wac-graph"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "wac-parser"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "wac-resolver"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "futures",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "wac-types"
-version = "0.4.0-dev"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ cargo binstall wac-cli
 The `wac` CLI tool has the following commands:
 
 * `wac plug` - Plugs the imports of a component with one or more other components.
+* `wac compose` - Compose WebAssembly components using the provided WAC source file.
 * `wac parse` - Parses a composition into a JSON representation of the AST.
 * `wac resolve` - Resolves a composition into a JSON representation.
-* `wac encode` - Encodes a WAC source file as a WebAssembly component.
 
 ### Quick & Easy Compositions
 
@@ -120,20 +120,20 @@ wac plug my-namespace:package-name --plug some-namespace:other-package-name -o p
 
 ### Encoding Compositions
 
-To encode a composition, use the `wac encode` command:
+To perform a composition, use the `wac compose` command:
 
 ```
-wac encode -t input.wac
+wac compose -t input.wac
 ```
 
-This will encode `input.wac` as a WebAssembly component and write the text
+This will use `input.wac` to perform the composition and write the text
 representation of the component to stdout.
 
 ```
-wac encode -o output.wasm input.wac
+wac compose -o output.wasm input.wac
 ```
 
-This will encode `input.wac` as a WebAssembly component named `output.wasm`.
+This will perform the composition specified in `input.wac` and output a WebAssembly component named `output.wasm`.
 
 #### Dependencies
 
@@ -143,7 +143,7 @@ to cause dependencies to be imported in the output component, use the
 `--import-dependencies` flag:
 
 ```
-wac encode --import-dependencies -o output.wasm input.wac
+wac compose --import-dependencies -o output.wasm input.wac
 ```
 
 Dependencies may be located within a `deps` subdirectory, with an expected structure of:
@@ -170,7 +170,7 @@ search for dependencies.
 The location of specific dependencies may also be specified with the `--dep` CLI option:
 
 ```
-wac encode --dep foo:bar=./baz.wasm -o output.wasm input.wac
+wac compose --dep foo:bar=./baz.wasm -o output.wasm input.wac
 ```
 
 By default, dependencies must be binary-encoded WebAssembly components; to

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,17 +34,17 @@ world root {
 
 The resulting composed component will therefore only have the exported `greet` function originally from the `greeter` component.
 
-## `wac encode`
+## `wac compose`
 
-`wac` can be used as a CLI tool. The `wac encode` command takes a wac script as input which defines how two components are composed together.
+`wac` can be used as a CLI tool. The `wac compose` command takes a wac script as input which defines how two components are composed together.
 
 Running the following command should produce a new component that is the composition of the `hello` and `greeter` components.
 
 ```bash
-wac encode script.wac -o composed.wasm
+wac compose script.wac -o composed.wasm
 ```
 
-*Note*: `wac encode` expects to find any input components inside of a `deps` folder in a directory named after the namespace part of the input component's name (however, this is configurable with the `--deps-dir` option). In our example, the wac script uses the `example:greeter` and `example:hello` input components so `wac encode` expects to find those components in the `deps/example` directory.
+*Note*: `wac compose` expects to find any input components inside of a `deps` folder in a directory named after the namespace part of the input component's name (however, this is configurable with the `--deps-dir` option). In our example, the wac script uses the `example:greeter` and `example:hello` input components so `wac compose` expects to find those components in the `deps/example` directory.
 
 ## `wac plug`
 

--- a/src/bin/wac.rs
+++ b/src/bin/wac.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use owo_colors::{OwoColorize, Stream, Style};
-use wac_cli::commands::{EncodeCommand, ParseCommand, PlugCommand, ResolveCommand};
+use wac_cli::commands::{ComposeCommand, ParseCommand, PlugCommand, ResolveCommand};
 
 fn version() -> &'static str {
     option_env!("CARGO_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
@@ -17,10 +17,10 @@ fn version() -> &'static str {
 )]
 #[command(version = version())]
 enum Wac {
+    Plug(PlugCommand),
+    Compose(ComposeCommand),
     Parse(ParseCommand),
     Resolve(ResolveCommand),
-    Encode(EncodeCommand),
-    Plug(PlugCommand),
 }
 
 #[tokio::main]
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     if let Err(e) = match Wac::parse() {
         Wac::Parse(cmd) => cmd.exec().await,
         Wac::Resolve(cmd) => cmd.exec().await,
-        Wac::Encode(cmd) => cmd.exec().await,
+        Wac::Compose(cmd) => cmd.exec().await,
         Wac::Plug(cmd) => cmd.exec().await,
     } {
         eprintln!(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,11 +1,11 @@
 //! Module for CLI commands.
 
-mod encode;
+mod compose;
 mod parse;
 mod plug;
 mod resolve;
 
-pub use self::encode::*;
+pub use self::compose::*;
 pub use self::parse::*;
 pub use self::plug::*;
 pub use self::resolve::*;

--- a/src/commands/compose.rs
+++ b/src/commands/compose.rs
@@ -25,10 +25,10 @@ where
     ))
 }
 
-/// Encodes a WAC source file into a WebAssembly component.
+/// Compose WebAssembly components using the provided WAC source file.
 #[derive(Args)]
 #[clap(disable_version_flag = true)]
-pub struct EncodeCommand {
+pub struct ComposeCommand {
     /// The directory to search for package dependencies.
     #[clap(long, value_name = "PATH", default_value = "deps")]
     pub deps_dir: PathBuf,
@@ -37,7 +37,7 @@ pub struct EncodeCommand {
     #[clap(long = "dep", short, value_name = "PKG=PATH", value_parser = parse::<String, PathBuf>)]
     pub deps: Vec<(String, PathBuf)>,
 
-    /// Whether to skip validation of the encoded WebAssembly component.
+    /// Whether to skip validation of the composed WebAssembly component.
     #[clap(long)]
     pub no_validate: bool,
 
@@ -69,10 +69,10 @@ pub struct EncodeCommand {
     pub path: PathBuf,
 }
 
-impl EncodeCommand {
+impl ComposeCommand {
     /// Executes the command.
     pub async fn exec(self) -> Result<()> {
-        log::debug!("executing encode command");
+        log::debug!("executing compose command");
 
         let contents = fs::read_to_string(&self.path)
             .with_context(|| format!("failed to read file `{path}`", path = self.path.display()))?;


### PR DESCRIPTION
Closes #52 

`wac encode` is a very reasonable name if you understand how wac works, but is likely to be less than ideal for newcomers. Such newcomers have heard that `wac` is a tool for composition, but when none of the subcommands directly indicate composition, they are likely to end up confused. 

Renaming to `wac compose` should reduce confusion. 