### PR TITLE
Build against musl on linux

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -28,9 +28,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust-target: x86_64-unknown-linux-gnu
+          - rust-target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - rust-target: aarch64-unknown-linux-gnu
+            cross: true
+          - rust-target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true
           - rust-target: x86_64-apple-darwin
@@ -70,9 +71,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust-target: x86_64-unknown-linux-gnu
+          - rust-target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - rust-target: aarch64-unknown-linux-gnu
+            cross: true
+          - rust-target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true
           - rust-target: x86_64-apple-darwin


### PR DESCRIPTION
Switched to using `cross` even on the x86_64 image, because it comes pre-installed with `musl-gcc`. The alternative would be to add a step that does `apt-get update && apt-get install musl-tools` just for `x86_64-unknown-linux-musl` but I felt this was simpler and more consistent across the x86_64 and aarch64 linux targets.

Happy to add a comment in the YAML file if we want that.

Fix #142