### PR TITLE
Enable all Wasm features in Validator

### DIFF
--- a/crates/wac-graph/src/graph.rs
+++ b/crates/wac-graph/src/graph.rs
@@ -1225,12 +1225,9 @@ impl CompositionGraph {
         let bytes = CompositionGraphEncoder::new(self).encode(options)?;
 
         if options.validate {
-            Validator::new_with_features(WasmFeatures {
-                component_model: true,
-                ..Default::default()
-            })
-            .validate_all(&bytes)
-            .map_err(|e| EncodeError::ValidationFailure { source: e })?;
+            Validator::new_with_features(WasmFeatures::all())
+                .validate_all(&bytes)
+                .map_err(|e| EncodeError::ValidationFailure { source: e })?;
         }
 
         Ok(bytes)

--- a/crates/wac-types/src/package.rs
+++ b/crates/wac-types/src/package.rs
@@ -200,10 +200,7 @@ impl Package {
 
         let mut parser = Parser::new(0);
         let mut parsers = Vec::new();
-        let mut validator = Validator::new_with_features(WasmFeatures {
-            component_model: true,
-            ..Default::default()
-        });
+        let mut validator = Validator::new_with_features(WasmFeatures::all());
         let mut imports = Vec::new();
         let mut exports = Vec::new();
 


### PR DESCRIPTION
fix https://github.com/bytecodealliance/wac/issues/145

Enable all Wasm features in the `Validator` so we can use components that rely on Wasm features that isn't enabled by default, such as `gc`.

---

This PR enabled all the Wasm features (a workaround (2) in https://github.com/bytecodealliance/wac/issues/145), but if we want to support command line arguments something like `--features` instead, let me know :)
( personally think it's reasonable that `wac` to support all features by default though)