### PR TITLE
Bump wasm-tools crates to 229

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,7 +4075,7 @@ dependencies = [
  "wac-types",
  "warg-client",
  "warg-protocol",
- "wasmprinter 0.227.1",
+ "wasmprinter 0.229.0",
  "wat",
  "wit-component",
  "wit-parser",
@@ -4096,10 +4096,10 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wac-types",
- "wasm-encoder 0.227.1",
+ "wasm-encoder 0.229.0",
  "wasm-metadata",
- "wasmparser 0.227.1",
- "wasmprinter 0.227.1",
+ "wasmparser 0.229.0",
+ "wasmprinter 0.229.0",
  "wat",
  "wit-component",
  "wit-parser",
@@ -4126,10 +4126,10 @@ dependencies = [
  "tokio",
  "wac-graph",
  "wac-resolver",
- "wasm-encoder 0.227.1",
+ "wasm-encoder 0.229.0",
  "wasm-metadata",
- "wasmparser 0.227.1",
- "wasmprinter 0.227.1",
+ "wasmparser 0.229.0",
+ "wasmprinter 0.229.0",
 ]
 
 [[package]]
@@ -4155,7 +4155,7 @@ dependencies = [
  "warg-crypto",
  "warg-protocol",
  "warg-server",
- "wasmprinter 0.227.1",
+ "wasmprinter 0.229.0",
  "wat",
  "wit-component",
  "wit-parser",
@@ -4170,8 +4170,8 @@ dependencies = [
  "indexmap 2.7.1",
  "semver",
  "serde 1.0.197",
- "wasm-encoder 0.227.1",
- "wasmparser 0.227.1",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
@@ -4473,19 +4473,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
+checksum = "38ba1d491ecacb085a2552025c10a675a6fddcbd03b1fc9b36c536010ce265d2"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.227.1",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
+checksum = "78fdb7d29a79191ab363dc90c1ddd3a1e880ffd5348d92d48482393a9e6c5f4d"
 dependencies = [
  "anyhow",
  "auditable-serde",
@@ -4496,8 +4496,8 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.227.1",
- "wasmparser 0.227.1",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
@@ -4526,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
+checksum = "0cc3b1f053f5d41aa55640a1fa9b6d1b8a9e4418d118ce308d20e24ff3575a8c"
 dependencies = [
  "bitflags 2.5.0",
  "hashbrown 0.15.2",
@@ -4549,33 +4549,33 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32475a0459db5639e989206dd8833fb07110ec092a7cb3468c82341989cac4d3"
+checksum = "d25dac01892684a99b8fbfaf670eb6b56edea8a096438c75392daeb83156ae2e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.227.1",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
 name = "wast"
-version = "227.0.1"
+version = "229.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c14e5042b16c9d267da3b9b0f4529870455178415286312c25c34dfc1b2816"
+checksum = "63fcaff613c12225696bb163f79ca38ffb40e9300eff0ff4b8aa8b2f7eadf0d9"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.227.1",
+ "wasm-encoder 0.229.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.227.1"
+version = "1.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d394d5bef7006ff63338d481ca10f1af76601e65ebdf5ed33d29302994e9cc"
+checksum = "4189bad08b70455a9e9e67dc126d2dcf91fac143a80f1046747a5dde6d4c33e0"
 dependencies = [
  "wast",
 ]
@@ -4840,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
+checksum = "7f550067740e223bfe6c4878998e81cdbe2529dd9a793dc49248dd6613394e8b"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -4851,18 +4851,18 @@ dependencies = [
  "serde 1.0.197",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.227.1",
+ "wasm-encoder 0.229.0",
  "wasm-metadata",
- "wasmparser 0.227.1",
+ "wasmparser 0.229.0",
  "wat",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.227.1"
+version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
+checksum = "459c6ba62bf511d6b5f2a845a2a736822e38059c1cfa0b644b467bbbfae4efa6"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4873,7 +4873,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.227.1",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,13 @@ wac-parser = { path = "crates/wac-parser", version = "0.7.0-dev", default-featur
 wac-resolver = { path = "crates/wac-resolver", version = "0.7.0-dev", default-features = false }
 wac-graph = { path = "crates/wac-graph", version = "0.7.0-dev" }
 wac-types = { path = "crates/wac-types", version = "0.7.0-dev" }
-wit-parser = "0.227.0"
-wasmparser = "0.227.0"
-wit-component = "0.227.0"
-wasm-encoder = "0.227.0"
-wasmprinter = "0.227.0"
-wasm-metadata = "0.227.0"
-wat = "1.227.0"
+wit-parser = "0.229.0"
+wasmparser = "0.229.0"
+wit-component = "0.229.0"
+wasm-encoder = "0.229.0"
+wasmprinter = "0.229.0"
+wasm-metadata = "0.229.0"
+wat = "1.229.0"
 anyhow = "1.0.81"
 clap = { version = "4.5.4", features = ["derive"] }
 semver = { version = "1.0.22", features = ["serde"] }


### PR DESCRIPTION
No changes needed in the source, so just updating for various async things.