### PR TITLE
Fix dev-dependencies for publishing

### DIFF
--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -379,6 +379,7 @@ fn verify(crates: &[Crate]) {
     fn verify_and_vendor(krate: &Crate) {
         let mut cmd = Command::new("cargo");
         cmd.arg("package")
+            .arg("--allow-dirty")
             .arg("--manifest-path")
             .arg(&krate.manifest)
             .env("CARGO_TARGET_DIR", "./target");

--- a/crates/wac-parser/Cargo.toml
+++ b/crates/wac-parser/Cargo.toml
@@ -25,7 +25,7 @@ wasm-metadata = { workspace = true }
 miette = { workspace = true, features = ["serde"]}
 
 [dev-dependencies]
-wac-resolver = { workspace = true, default-features = false, features = ["wat", "wit"] }
+wac-resolver = { path = "../wac-resolver", default-features = false, features = ["wat", "wit"] }
 owo-colors = "4.0.0"
 pretty_assertions = { workspace = true }
 pretty_env_logger = { workspace = true }

--- a/crates/wac-resolver/Cargo.toml
+++ b/crates/wac-resolver/Cargo.toml
@@ -28,9 +28,10 @@ tokio = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 
 [dev-dependencies]
-wac-graph = { workspace = true }
+wac-graph = { path = "../wac-graph" }
 wasmprinter = { workspace = true }
 warg-server = { workspace = true }
+wit-parser = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio-util = "0.7.10"
 tempdir = "0.3.7"

--- a/crates/wac-resolver/tests/support/mod.rs
+++ b/crates/wac-resolver/tests/support/mod.rs
@@ -46,7 +46,7 @@ pub async fn publish_wit(
     use std::io::Write;
     let mut resolve = Resolve::new();
     let mut tmp = tempfile::NamedTempFile::new()?;
-    tmp.write(wit.as_bytes())?;
+    tmp.write_all(wit.as_bytes())?;
     let path = tmp.path();
     let pkg = resolve
         .push_file(path)


### PR DESCRIPTION
This fixes some issues that have been effecting publishing / release the various crates here. 

Verified things are publishable by:
```
rustc ci/publish.rs
./publish verify
```