### PR TITLE
Add missing async/sync function type checking

### DIFF
--- a/crates/wac-graph/src/encoding.rs
+++ b/crates/wac-graph/src/encoding.rs
@@ -231,6 +231,7 @@ impl<'a> TypeEncoder<'a> {
         let result = ty.result.map(|ty| self.value_type(state, ty));
         let index = state.current.encodable.type_count();
         let mut encoder = state.current.encodable.ty().function();
+        encoder.async_(ty.is_async);
         encoder.params(params);
         encoder.result(result);
 

--- a/crates/wac-parser/src/resolution.rs
+++ b/crates/wac-parser/src/resolution.rs
@@ -2130,10 +2130,11 @@ impl<'a> AstResolver<'a> {
             }
         };
 
-        Ok(state
-            .graph
-            .types_mut()
-            .add_func_type(FuncType { params, result }))
+        Ok(state.graph.types_mut().add_func_type(FuncType {
+            params,
+            result,
+            is_async: false,
+        }))
     }
 
     fn expr(

--- a/crates/wac-types/src/aggregator.rs
+++ b/crates/wac-types/src/aggregator.rs
@@ -678,6 +678,7 @@ impl TypeAggregator {
                 .result
                 .map(|ty| self.remap_value_type(types, ty, checker))
                 .transpose()?,
+            is_async: ty.is_async,
         };
 
         let remapped_id = self.types.add_func_type(remapped);
@@ -958,6 +959,7 @@ mod tests {
         types.add_func_type(FuncType {
             params: IndexMap::new(),
             result: None,
+            is_async: false,
         })
     }
 

--- a/crates/wac-types/src/checker.rs
+++ b/crates/wac-types/src/checker.rs
@@ -171,6 +171,15 @@ impl<'a> SubtypeChecker<'a> {
         // rather than actual subtyping; the reason for this is that implementing
         // runtimes don't yet support more complex subtyping rules.
 
+        if a.is_async != b.is_async {
+            let (expected, _, found, _) = self.expected_found(a, at, b, bt);
+            bail!(
+                "expected {} function, found {} function",
+                if expected.is_async { "async" } else { "sync" },
+                if found.is_async { "async" } else { "sync" },
+            );
+        }
+
         if a.params.len() != b.params.len() {
             let (expected, _, found, _) = self.expected_found(a, at, b, bt);
             bail!(

--- a/crates/wac-types/src/component.rs
+++ b/crates/wac-types/src/component.rs
@@ -873,6 +873,8 @@ pub struct FuncType {
     pub params: IndexMap<String, ValueType>,
     /// The result of the function.
     pub result: Option<ValueType>,
+    /// Whether or not this is an async function.
+    pub is_async: bool,
 }
 
 impl FuncType {

--- a/crates/wac-types/src/package.rs
+++ b/crates/wac-types/src/package.rs
@@ -443,7 +443,11 @@ impl<'a> TypeConverter<'a> {
             None => None,
         };
 
-        let id = self.types.add_func_type(FuncType { params, result });
+        let id = self.types.add_func_type(FuncType {
+            params,
+            result,
+            is_async: func_ty.async_,
+        });
         self.cache.insert(key, Entity::Type(Type::Func(id)));
         Ok(id)
     }


### PR DESCRIPTION
wac-graph's FuncType didn't track whether a function is async. Its SubtypeChecker considered sync exports compatible with async source imports, producing a composed component that failed wasmparser validation.